### PR TITLE
Release v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,12 @@ tf_chef_compliance CHANGELOG
 
 This file is used to list changes made in each version of the tf_chef_compliance Terraform plan.
 
-v0.1.0 (2016-04-25)
+v0.1.2 (2016-04-25)
+-------------------
+- [Brian Menges] - Fix count on provisioner
+- [Brian Menges] - Implement break on license not accepted in `null_resource.compliance-prep`
+
+v0.1.1 (2016-04-25)
 -------------------
 - [Brian Menges] - Remove `boolean` map
 - [Brian Menges] - Update `accept_license`. true = `1`, false = `0`

--- a/main.tf
+++ b/main.tf
@@ -79,6 +79,13 @@ resource "null_resource" "compliance-prep" {
     private_key = "${var.aws_private_key_file}"
     host        = "${var.chef_fqdn}"
   }
+  # Check if we're accepting the license
+  provisioner "local-exec" {
+    command = <<-EOC
+      [ ${var.accept_license} -eq 1 ] && echo 'Chef MLSA License ACCEPTED' || echo 'Chef MLSA License NOT ACCEPTED'
+      [ ${var.accept_license} -eq 1 ] && exit 0 || exit 1
+      EOC
+  }
   # Push in some cookbooks
   provisioner "remote-exec" {
     script = "${path.module}/files/chef-cookbooks.sh"
@@ -155,7 +162,6 @@ resource "aws_instance" "chef-compliance" {
   }
 	# Accept license
   provisioner "remote-exec" {
-    count = "${var.accept_license}"
     inline = [
       "sudo touch /var/opt/chef-compliance/.license.accepted"
     ]


### PR DESCRIPTION
- [Brian Menges] - Fix count on provisioner
- [Brian Menges] - Implement break on license not accepted in `null_resource.compliance-prep`
